### PR TITLE
add the link of primers’ targeted phyla

### DIFF
--- a/Amplicon_dual_index_prep_EnvGen.rst
+++ b/Amplicon_dual_index_prep_EnvGen.rst
@@ -72,7 +72,7 @@ The figure below illustrates the development of the amplicon’s structure in ea
     
     Option 2: load primers with multi-channel pipette after loading the KAPA mastermix and DNA template. Start PCR amplification within 5 mins.
     
-    Here you can also find `16S and 18S rRNA primer sequences <https://github.com/EnvGen/LabProtocols/blob/master/Primer_sequences.rst>`_ and their `targeted phylums <https://github.com/huyue87/hello-world/files/160392/Primer_sequences_matched_RDP_database_Yue_2012Oct09.xlsx>`_ matching to RDP database.
+    Here you can also find `16S and 18S rRNA primer sequences <https://github.com/EnvGen/LabProtocols/blob/master/Primer_sequences.rst>`_ and their `targeted phyla <https://github.com/huyue87/hello-world/files/160392/Primer_sequences_matched_RDP_database_Yue_2012Oct09.xlsx>`_ matching to RDP database.
     
     Annealing temperatures for commonly used primer pairs::
 

--- a/Primer_sequences.rst
+++ b/Primer_sequences.rst
@@ -29,3 +29,5 @@ F and R mean Forward and Reverse, respectively
 The numbers for 16S primers refer to position in E. coli and the ones in 18S primers refer to S. cerevisiae positions
 
 For other primers, we recommend the review by `Klindworth et al <http://www.ncbi.nlm.nih.gov/pubmed/22933715>`_
+
+You can also find these primers’ `targeted phyla <https://github.com/huyue87/hello-world/files/160392/Primer_sequences_matched_RDP_database_Yue_2012Oct09.xlsx>`_ matching to RDP database.


### PR DESCRIPTION
1) add the link of primers’ targeted phyla under the primer sequence
table
2) correct typo in library prep protocol. change ‘phylums’ to ‘phyla’